### PR TITLE
Add delimiter as parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ let source = path.join(__dirname, 'report.csv');
 let destination = path.join(__dirname, 'converted_report.xlsx');
 
 try {
-  convertCsvToXlsx(source, destination);
+  convertCsvToXlsx(source, destination, ',');
 } catch (e) {
   console.error(e.toString());
 }

--- a/src/convertCsvToXlsx.js
+++ b/src/convertCsvToXlsx.js
@@ -7,13 +7,14 @@ const xlsx = require('xlsx');
  *
  * @param {string} source
  * @param {string} destination
+ * @param {string} delimiter
  *
  * @throws Error
  */
-function convertCsvToXlsx(source, destination) {
+function convertCsvToXlsx(source, destination, delimiter = ',') {
   // sanity checks
-  if (typeof source !== 'string' || typeof destination !== 'string') {
-    throw new Error(`"source" and "destination" arguments must be of type string.`);
+  if (typeof source !== 'string' || typeof destination !== 'string' || typeof delimiter !== 'string') {
+    throw new Error(`"source", "destination" and "delimiter" arguments must be of type string.`);
   }
 
   // source exists
@@ -26,13 +27,18 @@ function convertCsvToXlsx(source, destination) {
     throw new Error(`destination "${destination}" already exists.`);
   }
 
+  // delimiter not , or .
+  if (delimiter != ',' || delimiter != '.') {
+    throw new Error(`delimiter must be comma or dot`);
+  }
+
   // read source
   const csvFile = fs.readFileSync(source, 'UTF-8');
 
   // csv parser options
   const csvOptions = {
     columns: true,
-    delimiter: ',',
+    delimiter: delimiter,
     ltrim: true,
     rtrim: true,
   };

--- a/src/convertCsvToXlsx.js
+++ b/src/convertCsvToXlsx.js
@@ -28,7 +28,7 @@ function convertCsvToXlsx(source, destination, delimiter = ',') {
   }
 
   // delimiter not , or .
-  if (delimiter != ',' || delimiter != '.') {
+  if (delimiter !== ',' || delimiter !== '.') {
     throw new Error(`delimiter must be comma or dot`);
   }
 


### PR DESCRIPTION
As US citizens often use the dot as delimiter it would be nice to let the user choose which delimiter to use. 

Currently number with the dot as the delimiter (e.g. 1.23) are not recognized as numbers.

Here is a proposed change.