### PR TITLE
added (columns) option to keep duplicated columns

### DIFF
--- a/src/convertCsvToXlsx.ts
+++ b/src/convertCsvToXlsx.ts
@@ -12,7 +12,7 @@ import {APIParameters} from './convertCsvToXlsx.types';
 export function convertCsvToXlsx(
   source: string,
   destination: string,
-  {sheetName = '', overwrite = false}: APIParameters = {},
+  {sheetName = '', overwrite = false, columns = true}: APIParameters = {},
 ) {
   // sanity checks
   if (typeof source !== 'string' || typeof destination !== 'string') {
@@ -36,7 +36,7 @@ export function convertCsvToXlsx(
 
   // csv parser options
   const csvOptions = {
-    columns: true,
+    columns,
     delimiter: ',',
     ltrim: true,
     rtrim: true,
@@ -49,7 +49,7 @@ export function convertCsvToXlsx(
   const wb = xlsx.utils.book_new();
 
   // insert the records as a sheet
-  const ws = xlsx.utils.json_to_sheet(records);
+  const ws = xlsx.utils.json_to_sheet(records, { skipHeader: !columns });
   xlsx.utils.book_append_sheet(wb, ws, sheetName);
 
   // write the xlsx workbook to destination

--- a/src/convertCsvToXlsx.types.ts
+++ b/src/convertCsvToXlsx.types.ts
@@ -1,4 +1,5 @@
 export type APIParameters = {
   sheetName?: string;
   overwrite?: boolean;
+  columns?: boolean;
 };


### PR DESCRIPTION
when a csv file has duplicated columns, when converting it, it keeps the last column and ignores the previous ones, now, with (columns option) you can choose whether to go with this behavior or just keep columns as is.
default value is true, which means only last column of duplicated columns will be present